### PR TITLE
Change capitalization of English resources

### DIFF
--- a/EmbeddedLangFiles/addon_en_sv.xml
+++ b/EmbeddedLangFiles/addon_en_sv.xml
@@ -4,8 +4,8 @@
     <addon>
       <formsview-open>
         <command>
-          <label>Open in forms view</label>
-          <tooltip>Opens in forms view</tooltip>
+          <label>Open in Forms View</label>
+          <tooltip>Opens in Forms View</tooltip>
         </command>
       </formsview-open>
     </addon>


### PR DESCRIPTION
Hi and thanks for this add-on! 

It would be nice if the English labels could be updated to follow the same capitalization as the other items in the page context menu. So basically "Open in Forms View" instead of "Open in forms view".

Minor detail, but makes it fit in more :-)